### PR TITLE
Create Validator

### DIFF
--- a/src/main/scala/com/payit/validations/Validator.scala
+++ b/src/main/scala/com/payit/validations/Validator.scala
@@ -1,0 +1,24 @@
+package com.payit.validations
+
+trait Validator[T] extends (T => Validated[Map[String, Seq[ValidationFailure]], T]) {
+
+  def parentKey: ParentKey = ParentKey()
+
+  def ruleSets: Seq[RuleSet[T, _]]
+
+  def apply(obj: T): Validated[Map[String, Seq[ValidationFailure]], T] = {
+    var failures = Map[String, Seq[ValidationFailure]]()
+    ruleSets.foreach { ruleSet =>
+      ruleSet(obj) match {
+        case Success(_) => Nil
+        case Failed(f) => failures = (failures.values.flatMap(f => f) ++ f).groupBy{f =>
+          buildKey(f.key, f.parentKey)}.mapValues(_.map(f => f).toSeq.distinct)
+      }
+    }
+
+    if (failures.isEmpty) Success(obj) else Failed(failures)
+  }
+
+  protected def buildKey(key: String, parentKey: ParentKey): String = (parentKey.keys :+ key).mkString(".")
+  
+}

--- a/src/test/scala/com/payit/validations/ValidatorSpec.scala
+++ b/src/test/scala/com/payit/validations/ValidatorSpec.scala
@@ -1,0 +1,173 @@
+package com.payit.validations
+
+import org.specs2.mock.Mockito
+import org.specs2.mutable.Specification
+import org.specs2.validation.ValidationMatchers
+
+class ValidatorSpec extends Specification with ValidationMatchers with Mockito {
+
+  case class TestModel(v1: String = "Value1", v2: String = "Value2")
+  val model = TestModel()
+
+
+  ".apply" >> {
+    "when validation is successful" >> {
+      "it should return object being validated" >> {
+        val ruleSet = mock[RuleSet[TestModel, String]]
+        ruleSet.apply(model) returns Success[TestModel](model)
+        validator(ruleSet)(model) should beSuccessful(model)
+      }
+    }
+    "when validation fails" >> {
+      "using one RuleSet" >> {
+        "with no ParentKey" >> {
+          val ruleSet = mockFailedRuleSet("v1", "rule1", "msg1", model)
+          "it should return expected ValidationFailure" >> {
+            validator(ruleSet)(model) should beFailing(Map(
+              "v1" -> Seq(ValidationFailure(ParentKey(), "v1", "rule1", "msg1"))
+            ))
+          }
+        }
+        "with a ParentKey" >> {
+          val ruleSet = mockFailedRuleSet("v1", "rule1", "msg1", model, ParentKey("parent"))
+          "it should return expected ValidationFailure" >> {
+            validator(ruleSet)(model) should beFailing(Map(
+              "parent.v1" -> Seq(ValidationFailure(ParentKey("parent"), "v1", "rule1", "msg1"))
+            ))
+          }
+        }
+      }
+      "using 2 RuleSets" >> {
+        "when both do not have a ParentKey" >> {
+          "and the keys are different" >> {
+            val ruleSet1 = mockFailedRuleSet("v1", "rule1", "msg1", model)
+            val ruleSet2 = mockFailedRuleSet("v2", "rule1", "msg1", model)
+            "it should return expected ValidationFailures" >> {
+              validator(ruleSet1, ruleSet2)(model) should beFailing(Map(
+                "v1" -> Seq(ValidationFailure(ParentKey(), "v1", "rule1", "msg1")),
+                "v2" -> Seq(ValidationFailure(ParentKey(), "v2", "rule1", "msg1"))
+              ))
+            }
+          }
+          "and the keys are the same" >> {
+            val ruleSet1 = mockFailedRuleSet("v1", "rule1", "msg1", model)
+            val ruleSet2 = mockFailedRuleSet("v1", "rule2", "msg2", model)
+            "but each uses a different ValidationRule" >> {
+              "it should return 1 ValidationFailure with a combination of both ValidationRule failures" >> {
+                validator(ruleSet1, ruleSet2)(model) should beFailing(Map(
+                  "v1" -> Seq(
+                    ValidationFailure(ParentKey(), "v1", "rule1", "msg1"),
+                    ValidationFailure(ParentKey(), "v1", "rule2", "msg2")
+                  )
+                ))
+              }
+            }
+            "but each uses the same ValidationRule" >> {
+              val ruleSet1 = mockFailedRuleSet("v1", "rule1", "msg1", model)
+              val ruleSet2 = mockFailedRuleSet("v1", "rule1", "msg1", model)
+              "it should return 1 ValidationFailure with out duplicating a ValidationRule failure" >> {
+                validator(ruleSet1, ruleSet2)(model) should beFailing(Map(
+                  "v1" -> Seq(
+                    ValidationFailure(ParentKey(), "v1", "rule1", "msg1")
+                  )
+                ))
+              }
+            }
+          }
+        }
+        "when both have a ParentKey" >> {
+          "and the parent keys are different" >> {
+            "and the keys are different" >> {
+              val ruleSet1 = mockFailedRuleSet("v1", "rule1", "msg1", model, ParentKey("parent1"))
+              val ruleSet2 = mockFailedRuleSet("v2", "rule1", "msg1", model, ParentKey("parent2"))
+              "it should return 2 expected ValidationFailures" >> {
+                validator(ruleSet1, ruleSet2)(model) should beFailing(Map(
+                  "parent1.v1" -> Seq(
+                    ValidationFailure(ParentKey("parent1"), "v1", "rule1", "msg1")
+                  ),
+                  "parent2.v2" -> Seq(
+                    ValidationFailure(ParentKey("parent2"), "v2", "rule1", "msg1")
+                  )
+                ))
+              }
+            }
+            "and the keys are the same" >> {
+              val ruleSet1 = mockFailedRuleSet("v1", "rule1", "msg1", model, ParentKey("parent1"))
+              val ruleSet2 = mockFailedRuleSet("v1", "rule1", "msg1", model, ParentKey("parent2"))
+              "it should return 2 expected ValidationFailures" >> {
+                validator(ruleSet1, ruleSet2)(model) should beFailing(Map(
+                  "parent1.v1" -> Seq(
+                    ValidationFailure(ParentKey("parent1"), "v1", "rule1", "msg1")
+                  ),
+                  "parent2.v1" -> Seq(
+                    ValidationFailure(ParentKey("parent2"), "v1", "rule1", "msg1")
+                  )
+                ))
+              }
+            }
+          }
+          "and the parent keys are the same" >> {
+            "and the keys are different" >> {
+              val ruleSet1 = mockFailedRuleSet("v1", "rule1", "msg1", model, ParentKey("parent1"))
+              val ruleSet2 = mockFailedRuleSet("v2", "rule1", "msg1", model, ParentKey("parent1"))
+              "it should return 2 expected ValidationFailures" >> {
+                validator(ruleSet1, ruleSet2)(model) should beFailing(Map(
+                  "parent1.v1" -> Seq(
+                    ValidationFailure(ParentKey("parent1"), "v1", "rule1", "msg1")
+                  ),
+                  "parent1.v2" -> Seq(
+                    ValidationFailure(ParentKey("parent1"), "v2", "rule1", "msg1")
+                  )
+                ))
+              }
+            }
+            "and the keys are the same" >> {
+              val ruleSet1 = mockFailedRuleSet("v1", "rule1", "msg1", model, ParentKey("parent1"))
+              val ruleSet2 = mockFailedRuleSet("v1", "rule2", "msg2", model, ParentKey("parent1"))
+              "it should return 1 ValidationFailure with a combination of both ValidationRule failures" >> {
+                validator(ruleSet1, ruleSet2)(model) should beFailing(Map(
+                  "parent1.v1" -> Seq(
+                    ValidationFailure(ParentKey("parent1"), "v1", "rule1", "msg1"),
+                    ValidationFailure(ParentKey("parent1"), "v1", "rule2", "msg2")
+                  )
+                ))
+              }
+              "but each uses the same ValidationRule" >> {
+                val ruleSet1 = mockFailedRuleSet("v1", "rule1", "msg1", model, ParentKey("parent1"))
+                val ruleSet2 = mockFailedRuleSet("v1", "rule1", "msg1", model, ParentKey("parent1"))
+                "it should return 1 ValidationFailure with out duplicating a ValidationRule failure" >> {
+                  validator(ruleSet1, ruleSet2)(model) should beFailing(Map(
+                    "parent1.v1" -> Seq(
+                      ValidationFailure(ParentKey("parent1"), "v1", "rule1", "msg1")
+                    )
+                  ))
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private def validator(sets: RuleSet[TestModel, String]*): Validator[TestModel] = {
+    new Validator[TestModel] {
+      val ruleSets = sets.toSeq
+    }
+  }
+
+  private def mockFailedRuleSet(
+    key: String,
+    ruleKey: String,
+    msg: String,
+    model: TestModel,
+    parentKey: ParentKey = ParentKey()) =
+  {
+    val ruleSet = mock[RuleSet[TestModel, String]]
+    ruleSet.parentKey returns parentKey
+    ruleSet.key returns key
+    ruleSet.apply(model) returns Failed(Seq[ValidationFailure](ValidationFailure(parentKey, key, ruleKey, msg)))
+    ruleSet
+  }
+
+}


### PR DESCRIPTION
Creates a trait that can be used to run a collection of rule sets and return a map of failures by a key/parent key path identifier or just return the value under validation if all validation rules pass.
